### PR TITLE
Clean Arch with some tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Android Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Run Tests
+        run: ./gradlew test
+
+      - name: Upload a Build Artifact (APK)
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: app
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
     testImplementation 'junit:junit:4.+'
+    testImplementation "com.google.truth:truth:1.1.3"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/app/src/main/java/com/eeyan/cryptapp/data/mappers/DtoToDomain.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/data/mappers/DtoToDomain.kt
@@ -1,0 +1,29 @@
+package com.eeyan.cryptapp.data.mappers
+
+import com.eeyan.cryptapp.data.remote.dto.CoinDetailDto
+import com.eeyan.cryptapp.data.remote.dto.CoinDto
+import com.eeyan.cryptapp.domain.model.Coin
+import com.eeyan.cryptapp.domain.model.CoinDetail
+
+fun CoinDto.toCoin() : Coin {
+    return Coin(
+        id = id,
+        is_active = is_active,
+        name = name,
+        rank = rank,
+        symbol = symbol
+    )
+}
+
+fun CoinDetailDto.toCoinDetail() : CoinDetail {
+    return CoinDetail(
+        coinId = coinId,
+        name = name,
+        description = description,
+        symbol = symbol,
+        rank = rank,
+        team = team,
+        tags = tags.map { it.name },
+        isActive = isActive
+    )
+}

--- a/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDetailDto.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDetailDto.kt
@@ -1,6 +1,7 @@
 package com.eeyan.cryptapp.data.remote.dto
 
 import com.eeyan.cryptapp.domain.model.CoinDetail
+import com.google.gson.annotations.SerializedName
 
 data class CoinDetailDto(
     val description: String,
@@ -8,7 +9,8 @@ data class CoinDetailDto(
     val first_data_at: String,
     val hardware_wallet: Boolean,
     val hash_algorithm: String,
-    val id: String,
+    @SerializedName("id")
+    val coinId: String,
     val is_active: Boolean,
     val is_new: Boolean,
     val last_data_at: String,
@@ -28,15 +30,3 @@ data class CoinDetailDto(
     val whitepaper: Whitepaper
 )
 
-fun CoinDetailDto.toCoinDetail() : CoinDetail{
-    return CoinDetail(
-        coinId = id,
-        name = name,
-        description = description,
-        symbol = symbol,
-        rank = rank,
-        team = team,
-        tags = tags.map { it.name },
-        isActive = is_active
-    )
-}

--- a/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDetailDto.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDetailDto.kt
@@ -11,7 +11,8 @@ data class CoinDetailDto(
     val hash_algorithm: String,
     @SerializedName("id")
     val coinId: String,
-    val is_active: Boolean,
+    @SerializedName("is_active")
+    val isActive: Boolean,
     val is_new: Boolean,
     val last_data_at: String,
     val links: Links,

--- a/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDto.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/data/remote/dto/CoinDto.kt
@@ -1,6 +1,6 @@
 package com.eeyan.cryptapp.data.remote.dto
 
-import com.eeyan.cryptapp.domain.model.Coin
+
 
 data class CoinDto(
     val id: String,
@@ -12,8 +12,3 @@ data class CoinDto(
     val type: String
 )
 
-fun CoinDto.toCoin() : Coin{
-    return Coin(
-        id, is_active, name, rank, symbol
-    )
-}

--- a/app/src/main/java/com/eeyan/cryptapp/data/repository/CoinRepositoryImpl.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/data/repository/CoinRepositoryImpl.kt
@@ -1,9 +1,9 @@
-package com.eeyan.cryptapp.domain.repository
+package com.eeyan.cryptapp.data.repository
 
 import com.eeyan.cryptapp.data.remote.CoinPaprikaApi
 import com.eeyan.cryptapp.data.remote.dto.CoinDetailDto
 import com.eeyan.cryptapp.data.remote.dto.CoinDto
-import com.eeyan.cryptapp.data.repository.CoinRepository
+import com.eeyan.cryptapp.domain.repository.CoinRepository
 import javax.inject.Inject
 
 class CoinRepositoryImpl
@@ -16,6 +16,4 @@ class CoinRepositoryImpl
     override suspend fun getCoinById(id: String): CoinDetailDto {
         return api.getCoinById(id)
     }
-
-
 }

--- a/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
@@ -8,9 +8,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
+import okhttp3.logging.HttpLoggingInterceptor
+import java.util.concurrent.TimeUnit
 
 
 @Module
@@ -19,19 +22,32 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun providePaprikaApi() : CoinPaprikaApi{
+    fun providePaprikaApi(okHttpClient: OkHttpClient): CoinPaprikaApi {
         return Retrofit.Builder()
             .baseUrl(Constants.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .client(okHttpClient)
             .build()
             .create(CoinPaprikaApi::class.java)
     }
-
 
     @Provides
     @Singleton
     fun provideCoinRepository(api: CoinPaprikaApi) : CoinRepository {
         return CoinRepositoryImpl(api)
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor): OkHttpClient {
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .callTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+
+        return okHttpClient.build()
     }
 
 }

--- a/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
@@ -2,8 +2,8 @@ package com.eeyan.cryptapp.di
 
 import com.eeyan.cryptapp.common.Constants
 import com.eeyan.cryptapp.data.remote.CoinPaprikaApi
-import com.eeyan.cryptapp.data.repository.CoinRepository
-import com.eeyan.cryptapp.domain.repository.CoinRepositoryImpl
+import com.eeyan.cryptapp.domain.repository.CoinRepository
+import com.eeyan.cryptapp.data.repository.CoinRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,7 +30,7 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideCoinRepository(api: CoinPaprikaApi) : CoinRepository{
+    fun provideCoinRepository(api: CoinPaprikaApi) : CoinRepository {
         return CoinRepositoryImpl(api)
     }
 

--- a/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/di/AppModule.kt
@@ -20,6 +20,12 @@ import java.util.concurrent.TimeUnit
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
+    @Singleton
+    @Provides
+    fun provideLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
+    }
+
     @Provides
     @Singleton
     fun providePaprikaApi(okHttpClient: OkHttpClient): CoinPaprikaApi {

--- a/app/src/main/java/com/eeyan/cryptapp/domain/repository/CoinRepository.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/domain/repository/CoinRepository.kt
@@ -1,4 +1,4 @@
-package com.eeyan.cryptapp.data.repository
+package com.eeyan.cryptapp.domain.repository
 
 import com.eeyan.cryptapp.data.remote.dto.CoinDetailDto
 import com.eeyan.cryptapp.data.remote.dto.CoinDto

--- a/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coin/GetCoinUseCase.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coin/GetCoinUseCase.kt
@@ -1,10 +1,8 @@
 package com.eeyan.cryptapp.domain.use_case.get_coin
 
 import com.eeyan.cryptapp.common.Resource
-import com.eeyan.cryptapp.data.remote.dto.toCoin
 import com.eeyan.cryptapp.data.remote.dto.toCoinDetail
-import com.eeyan.cryptapp.data.repository.CoinRepository
-import com.eeyan.cryptapp.domain.model.Coin
+import com.eeyan.cryptapp.domain.repository.CoinRepository
 import com.eeyan.cryptapp.domain.model.CoinDetail
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coin/GetCoinUseCase.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coin/GetCoinUseCase.kt
@@ -1,7 +1,7 @@
 package com.eeyan.cryptapp.domain.use_case.get_coin
 
 import com.eeyan.cryptapp.common.Resource
-import com.eeyan.cryptapp.data.remote.dto.toCoinDetail
+import com.eeyan.cryptapp.data.mappers.toCoinDetail
 import com.eeyan.cryptapp.domain.repository.CoinRepository
 import com.eeyan.cryptapp.domain.model.CoinDetail
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coins/GetCoinsUseCase.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coins/GetCoinsUseCase.kt
@@ -2,7 +2,7 @@ package com.eeyan.cryptapp.domain.use_case.get_coins
 
 import com.eeyan.cryptapp.common.Resource
 import com.eeyan.cryptapp.data.remote.dto.toCoin
-import com.eeyan.cryptapp.data.repository.CoinRepository
+import com.eeyan.cryptapp.domain.repository.CoinRepository
 import com.eeyan.cryptapp.domain.model.Coin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -24,8 +24,10 @@ class GetCoinsUseCase
                 emit(Resource.Success(coins))
             }catch (e : HttpException){
                 //error
+                e.printStackTrace()
                 emit(Resource.Error<List<Coin>>(e.localizedMessage?: "An unexpected error occurred"))
             }catch (e: IOException){
+                e.printStackTrace()
                 emit(Resource.Error<List<Coin>>("Could not reach server! Check internet connection"))
             }
 

--- a/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coins/GetCoinsUseCase.kt
+++ b/app/src/main/java/com/eeyan/cryptapp/domain/use_case/get_coins/GetCoinsUseCase.kt
@@ -1,7 +1,7 @@
 package com.eeyan.cryptapp.domain.use_case.get_coins
 
 import com.eeyan.cryptapp.common.Resource
-import com.eeyan.cryptapp.data.remote.dto.toCoin
+import com.eeyan.cryptapp.data.mappers.toCoin
 import com.eeyan.cryptapp.domain.repository.CoinRepository
 import com.eeyan.cryptapp.domain.model.Coin
 import kotlinx.coroutines.flow.Flow

--- a/app/src/test/java/com/eeyan/cryptapp/data/mappers/DtoToDomainKtTest.kt
+++ b/app/src/test/java/com/eeyan/cryptapp/data/mappers/DtoToDomainKtTest.kt
@@ -1,13 +1,7 @@
 package com.eeyan.cryptapp.data.mappers
 
-import com.eeyan.cryptapp.data.remote.dto.CoinDetailDto
-import com.eeyan.cryptapp.data.remote.dto.CoinDto
-import com.eeyan.cryptapp.data.remote.dto.Whitepaper
-import com.eeyan.cryptapp.data.utils.LinksExtendedUtil
-import com.eeyan.cryptapp.data.utils.TeamMemberUtil
-import com.eeyan.cryptapp.data.utils.links
-import com.eeyan.cryptapp.domain.model.Coin
-import com.eeyan.cryptapp.domain.model.CoinDetail
+
+import com.eeyan.cryptapp.data.utils.*
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
@@ -17,62 +11,15 @@ class DtoToDomainKtTest {
 
     @Test
     fun `confirm that CoinDto toCoin results to Coin`() {
-        val coinDto = CoinDto(
-            id = "android",
-            is_active = false,
-            is_new = true,
-            name = "name",
-            rank = 10,
-            symbol = "symbol",
-            type = "type"
-        )
-        val coin = Coin(
-            id = "android",
-            is_active = false,
-            name = "name",
-            rank = 10,
-            symbol = "symbol",
-        )
+        val coinDto = coinDtoTestUtil
+        val coin = coinTestUtil
         assertThat(coinDto.toCoin()).isEqualTo(coin)
     }
 
     @Test
     fun `confirm that toCoinDetail toDomain results to Coin`() {
-        val coinDetailDto = CoinDetailDto(
-            coinId = "bitcoin",
-            isActive = false,
-            is_new = true,
-            name = "name",
-            description = "Bitcoin is a decentralized digital currency",
-            rank = 10,
-            symbol = "symbol",
-            tags = listOf(),
-            team = listOf(TeamMemberUtil),
-            development_status = "",
-            first_data_at = "",
-            hardware_wallet = false,
-            hash_algorithm = "",
-            last_data_at = "",
-            links = links,
-            links_extended = listOf(LinksExtendedUtil),
-            message = "",
-            open_source = true,
-            org_structure = "",
-            proof_type = "",
-            started_at = "",
-            whitepaper = Whitepaper(link = "", thumbnail = ""),
-            type = ""
-        )
-        val coinDetail = CoinDetail(
-            coinId = "bitcoin",
-            isActive = false,
-            name = "name",
-            description = "Bitcoin is a decentralized digital currency",
-            rank = 10,
-            symbol = "symbol",
-            tags = listOf(),
-            team = listOf(TeamMemberUtil)
-        )
+        val coinDetailDto = coinDetailDtoTestUtil
+        val coinDetail = coinDetailTestUtil
         assertThat(coinDetailDto.toCoinDetail()).isEqualTo(coinDetail)
     }
 }

--- a/app/src/test/java/com/eeyan/cryptapp/data/mappers/DtoToDomainKtTest.kt
+++ b/app/src/test/java/com/eeyan/cryptapp/data/mappers/DtoToDomainKtTest.kt
@@ -1,0 +1,78 @@
+package com.eeyan.cryptapp.data.mappers
+
+import com.eeyan.cryptapp.data.remote.dto.CoinDetailDto
+import com.eeyan.cryptapp.data.remote.dto.CoinDto
+import com.eeyan.cryptapp.data.remote.dto.Whitepaper
+import com.eeyan.cryptapp.data.utils.LinksExtendedUtil
+import com.eeyan.cryptapp.data.utils.TeamMemberUtil
+import com.eeyan.cryptapp.data.utils.links
+import com.eeyan.cryptapp.domain.model.Coin
+import com.eeyan.cryptapp.domain.model.CoinDetail
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+
+
+class DtoToDomainKtTest {
+
+    @Test
+    fun `confirm that CoinDto toCoin results to Coin`() {
+        val coinDto = CoinDto(
+            id = "android",
+            is_active = false,
+            is_new = true,
+            name = "name",
+            rank = 10,
+            symbol = "symbol",
+            type = "type"
+        )
+        val coin = Coin(
+            id = "android",
+            is_active = false,
+            name = "name",
+            rank = 10,
+            symbol = "symbol",
+        )
+        assertThat(coinDto.toCoin()).isEqualTo(coin)
+    }
+
+    @Test
+    fun `confirm that toCoinDetail toDomain results to Coin`() {
+        val coinDetailDto = CoinDetailDto(
+            coinId = "bitcoin",
+            isActive = false,
+            is_new = true,
+            name = "name",
+            description = "Bitcoin is a decentralized digital currency",
+            rank = 10,
+            symbol = "symbol",
+            tags = listOf(),
+            team = listOf(TeamMemberUtil),
+            development_status = "",
+            first_data_at = "",
+            hardware_wallet = false,
+            hash_algorithm = "",
+            last_data_at = "",
+            links = links,
+            links_extended = listOf(LinksExtendedUtil),
+            message = "",
+            open_source = true,
+            org_structure = "",
+            proof_type = "",
+            started_at = "",
+            whitepaper = Whitepaper(link = "", thumbnail = ""),
+            type = ""
+        )
+        val coinDetail = CoinDetail(
+            coinId = "bitcoin",
+            isActive = false,
+            name = "name",
+            description = "Bitcoin is a decentralized digital currency",
+            rank = 10,
+            symbol = "symbol",
+            tags = listOf(),
+            team = listOf(TeamMemberUtil)
+        )
+        assertThat(coinDetailDto.toCoinDetail()).isEqualTo(coinDetail)
+    }
+}

--- a/app/src/test/java/com/eeyan/cryptapp/data/utils/TestUtils.kt
+++ b/app/src/test/java/com/eeyan/cryptapp/data/utils/TestUtils.kt
@@ -1,0 +1,27 @@
+package com.eeyan.cryptapp.data.utils
+
+import com.eeyan.cryptapp.data.remote.dto.Links
+import com.eeyan.cryptapp.data.remote.dto.LinksExtended
+import com.eeyan.cryptapp.data.remote.dto.Stats
+import com.eeyan.cryptapp.data.remote.dto.TeamMember
+
+val TeamMemberUtil = TeamMember(
+    id = "xyz",
+    name = "kanake",
+    position = "android developer"
+)
+
+val links = Links(
+    explorer = listOf(),
+    facebook = listOf(),
+    reddit = listOf(),
+    source_code = listOf(),
+    website = listOf(),
+    youtube = listOf()
+)
+
+val LinksExtendedUtil = LinksExtended(
+    stats = Stats(contributors = 1, followers = 2, stars = 3, subscribers = 4),
+    type = "",
+    url = ""
+)

--- a/app/src/test/java/com/eeyan/cryptapp/data/utils/TestUtils.kt
+++ b/app/src/test/java/com/eeyan/cryptapp/data/utils/TestUtils.kt
@@ -1,9 +1,8 @@
 package com.eeyan.cryptapp.data.utils
 
-import com.eeyan.cryptapp.data.remote.dto.Links
-import com.eeyan.cryptapp.data.remote.dto.LinksExtended
-import com.eeyan.cryptapp.data.remote.dto.Stats
-import com.eeyan.cryptapp.data.remote.dto.TeamMember
+import com.eeyan.cryptapp.data.remote.dto.*
+import com.eeyan.cryptapp.domain.model.Coin
+import com.eeyan.cryptapp.domain.model.CoinDetail
 
 val TeamMemberUtil = TeamMember(
     id = "xyz",
@@ -24,4 +23,59 @@ val LinksExtendedUtil = LinksExtended(
     stats = Stats(contributors = 1, followers = 2, stars = 3, subscribers = 4),
     type = "",
     url = ""
+)
+
+val coinDtoTestUtil = CoinDto(
+    id = "android",
+    is_active = false,
+    is_new = true,
+    name = "name",
+    rank = 10,
+    symbol = "symbol",
+    type = "type"
+)
+
+val coinTestUtil = Coin(
+    id = "android",
+    is_active = false,
+    name = "name",
+    rank = 10,
+    symbol = "symbol",
+)
+
+val coinDetailDtoTestUtil = CoinDetailDto(
+    coinId = "bitcoin",
+    isActive = false,
+    is_new = true,
+    name = "name",
+    description = "Bitcoin is a decentralized digital currency",
+    rank = 10,
+    symbol = "symbol",
+    tags = listOf(),
+    team = listOf(TeamMemberUtil),
+    development_status = "",
+    first_data_at = "",
+    hardware_wallet = false,
+    hash_algorithm = "",
+    last_data_at = "",
+    links = links,
+    links_extended = listOf(LinksExtendedUtil),
+    message = "",
+    open_source = true,
+    org_structure = "",
+    proof_type = "",
+    started_at = "",
+    whitepaper = Whitepaper(link = "", thumbnail = ""),
+    type = ""
+)
+
+val coinDetailTestUtil = CoinDetail(
+    coinId = "bitcoin",
+    isActive = false,
+    name = "name",
+    description = "Bitcoin is a decentralized digital currency",
+    rank = 10,
+    symbol = "symbol",
+    tags = listOf(),
+    team = listOf(TeamMemberUtil)
 )


### PR DESCRIPTION
This is an enhancement PR, which does the following:

- moves the repositoryImpl classes from domain package to data to follow clean Architecture
- correctly renames vals in dto to match those in domain to make sure tests pass
- ensure correct package importation 
- create a separate mappers file to easily test it
- Tests the DtoToDomain file,passing
- debugs the api calls using okhttp
- Runs a CI pipeline using github actions

Tests Passing
![Screenshot 2022-11-15 at 00 36 36](https://user-images.githubusercontent.com/77957614/201779351-1fb2f36d-8170-459f-bd7d-2ded7f11695e.png)
 